### PR TITLE
Add support for Push, Move and Note manuals (all languages)

### DIFF
--- a/ableton-manual-enhanced.user.css
+++ b/ableton-manual-enhanced.user.css
@@ -1,12 +1,11 @@
 /* ==UserStyle==
 @name           Ableton Live Reference Manual - Enhanced
-@description    Improves the online Ableton Live Reference Manual with a fixed table of contents and an optional dark theme.
+@description    Improves the online Ableton Live, Push, Move, and Note reference manuals with a fixed table of contents and optional dark theme.
 @author         allenmp3 (https://github.com/allenmp3)
 @namespace      https://github.com/allenmp3/ableton-live-manual-custom-css
 @homepageURL    https://github.com/allenmp3/ableton-live-manual-custom-css
-
 @license        MIT
-@version        1.0.0
+@version        1.1.0
 
 @preprocessor stylus
 @var  checkbox fixSidebarEnable "Use fixed sidebar (table of contents)" 1
@@ -15,7 +14,7 @@
 @var  checkbox darkThemeEnable "Always use dark theme" 0
 ==/UserStyle== */
 
-@-moz-document url-prefix("https://www.ableton.com/en/live-manual"), url-prefix("https://www.ableton.com/en/manual") {
+@-moz-document url-prefix("https://www.ableton.com/en/live-manual"), url-prefix("https://www.ableton.com/en/manual"), regexp("https://www\\.ableton\\.com/.*/push/manual/.*"), regexp("https://www\\.ableton\\.com/.*/move/manual/.*"), regexp("https://www\\.ableton\\.com/.*/note/manual/.*") {
   if fixSidebarEnable {
     /* Fixed sidebar */
     #sidebar {

--- a/ableton-manual-enhanced.user.css
+++ b/ableton-manual-enhanced.user.css
@@ -8,7 +8,7 @@
 @version        1.1.0
 
 @preprocessor stylus
-@var  checkbox fixSidebarEnable "Use fixed sidebar (table of contents)" 1
+@var  checkbox fixSidebarEnable "Enable fixed/sticky sidebar navigation" 1
 @var  checkbox headFootDisable "Hide header and footer" 1
 @var  checkbox followSysThemeEnable "Follow system light/dark theme" 1
 @var  checkbox darkThemeEnable "Always use dark theme" 0


### PR DESCRIPTION
* Extension now enabled on Push, Move and Note manuals.
* All languages supported. As of 2026-03-02, these are: 
  * `en` (English) — Live, Push, Move, Note
  * `de` (Deutsch) — Push, Move, Note
  * `fr` (français) — Push, Move, Note
  * `ja` (日本語) — Push, Move, Note
  * `zh-cn` (简体中文) — Push, Move, Note
  * `es` (español) — Push, Move
  * `it` (italiano) — Push, Move
* Improved wording for the fixed sidebar navigation option.

Closes #1.